### PR TITLE
Add cancel-rpc-tx command for E2E cancellation testing

### DIFF
--- a/cmd/mevrepl/main.go
+++ b/cmd/mevrepl/main.go
@@ -211,6 +211,14 @@ func main() {
 		Action:      handler.CancelRelayTx(ctx),
 	}
 
+	cancelRpcTxCmd := &cli.Command{
+		Name:        "cancel-rpc-tx",
+		Aliases:     []string{"crpc"},
+		Description: "cancel private tx via RPC using self-transfer detection",
+		Flags:       txFlags,
+		Action:      handler.CancelRpcTx(ctx),
+	}
+
 	// This command calls Flashbots Protect Transaction Status API and logs info txStatus
 	//
 	// For details, see: https://docs.flashbots.net/flashbots-protect/additional-documentation/status-api
@@ -260,7 +268,7 @@ func main() {
 		Action:      handler.Backrun(ctx),
 	}
 
-	app.Commands = append(app.Commands, sendPrivateTxCmd, sendFakeTxCmd, txStatusCmd, hintsStreamCmd, backrunCmd, sendPrivateRelayTxCmd, ethCallBundleCmd, ethSendBundleCmd, cancelRelayTxCmd, ethCancelBundleCmd)
+	app.Commands = append(app.Commands, sendPrivateTxCmd, sendFakeTxCmd, txStatusCmd, hintsStreamCmd, backrunCmd, sendPrivateRelayTxCmd, ethCallBundleCmd, ethSendBundleCmd, cancelRelayTxCmd, cancelRpcTxCmd, ethCancelBundleCmd)
 
 	if err := app.Run(os.Args); err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary
Adds `cancel-rpc-tx` command to test protect-rpc's self-transfer cancellation detection.

## Changes
- New command sends original tx + self-transfer with same nonce
- protect-rpc detects pattern (to == sender && data <= 2 bytes) and cancels via protect-of-api
- Mirrors `cancel-relay-tx` structure for consistent E2E testing

## Testing
```bash
export FLASHBOTS_RPC_URL=https://rpc-staging.flashbots.net
export FLASHBOTS_PROTECT_URL=https://protect-staging.flashbots.net
NETWORK=sepolia ./mevrepl cancel-rpc-tx --eth-amount 1000000000000000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)